### PR TITLE
Fixed headers

### DIFF
--- a/group/index.md
+++ b/group/index.md
@@ -11,7 +11,7 @@ image:
   feature:
 ---
 
-###Current Members
+### Current Members
   - Justin Wagner  
  Ph.D., Computer Science
 
@@ -34,7 +34,7 @@ B.S., Computer Science
 - Jayaram Kancherla  
 Faculty Research Assistant
 
-###Past Members
+### Past Members
 - Wikum Dinalankara  
 Ph.D., Computer Science.  
 First position: Postdoc, Johns Hopkins University


### PR DESCRIPTION
Added a space in the headers for markdown to properly convert to HTML. 
![hcbravo](https://cloud.githubusercontent.com/assets/10342878/22525842/f13063e0-e896-11e6-805d-322be15705d0.jpeg)

